### PR TITLE
Include OkHttp since customers typically use that; Finish the activity on Back Press

### DIFF
--- a/BasicRealTime/build.gradle
+++ b/BasicRealTime/build.gradle
@@ -36,7 +36,8 @@ android {
 dependencies {
     implementation 'com.amazonaws:ivs-broadcast:1.12.1:stages@aar'
 
-    // The IVS SDK works without OkHttp, but customers typically use OkHttp so let's follow that
+    // The Amazon IVS SDK works without OkHttp, but because many applications include it,
+    // we are including it this demo app to mimic real world behavior
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 
     implementation 'androidx.core:core-ktx:1.10.1'

--- a/BasicRealTime/build.gradle
+++ b/BasicRealTime/build.gradle
@@ -35,6 +35,10 @@ android {
 
 dependencies {
     implementation 'com.amazonaws:ivs-broadcast:1.12.1:stages@aar'
+
+    // The IVS SDK works without OkHttp, but customers typically use OkHttp so let's follow that
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation "androidx.activity:activity-ktx:1.7.2"
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/BasicRealTime/build.gradle
+++ b/BasicRealTime/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.amazonaws:ivs-broadcast:1.12.1:stages@aar'
 
     // The Amazon IVS SDK works without OkHttp, but because many applications include it,
-    // we are including it this demo app to mimic real world behavior
+    // so we are including it in this demo app to mimic real world behavior
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 
     implementation 'androidx.core:core-ktx:1.10.1'

--- a/BasicRealTime/src/main/java/com/amazonaws/ivs/realtime/basicrealtime/MainActivity.kt
+++ b/BasicRealTime/src/main/java/com/amazonaws/ivs/realtime/basicrealtime/MainActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -67,6 +68,12 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                finish()
+            }
+        })
     }
 
     override fun onStart() {


### PR DESCRIPTION
*Description of changes:*

1 - Include OkHttp since customers typically use that
2 - Finish the activity on back press - Android 12 and newer will not do that, and you end up with the activity running in the background, annoying

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
